### PR TITLE
Design/#8

### DIFF
--- a/bookduck/src/App.jsx
+++ b/bookduck/src/App.jsx
@@ -1,9 +1,10 @@
 import { Routes, Route } from "react-router-dom";
 import HomePage from "./pages/HomePage";
+import TextField from "./components/common/TextField";
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<HomePage />} />
+      <Route path="/" element={<TextField type="내용" title="제목" />} />
     </Routes>
   );
 }

--- a/bookduck/src/App.jsx
+++ b/bookduck/src/App.jsx
@@ -3,30 +3,9 @@ import HomePage from "./pages/HomePage";
 import TextField from "./components/common/TextField";
 import { useState } from "react";
 function App() {
-  const [error, setError] = useState(false);
-  const [isSubmitted, setIsSubmitted] = useState(false);
-
-  const handleEdit = () => {
-    setError(true);
-    setIsSubmitted(true);
-  };
   return (
     <Routes>
-      <Route
-        path="/"
-        element={
-          <TextField
-            type="내용"
-            placeholder="이메일입력"
-            title="로그인정보"
-            check={false}
-            handleEdit={handleEdit}
-            error={error}
-            isSubmitted={isSubmitted}
-            defaultType={true}
-          />
-        }
-      />
+      <Route path="/" element={<HomePage />} />
     </Routes>
   );
 }

--- a/bookduck/src/App.jsx
+++ b/bookduck/src/App.jsx
@@ -1,10 +1,32 @@
 import { Routes, Route } from "react-router-dom";
 import HomePage from "./pages/HomePage";
 import TextField from "./components/common/TextField";
+import { useState } from "react";
 function App() {
+  const [error, setError] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const handleEdit = () => {
+    setError(true);
+    setIsSubmitted(true);
+  };
   return (
     <Routes>
-      <Route path="/" element={<TextField type="내용" title="제목" />} />
+      <Route
+        path="/"
+        element={
+          <TextField
+            type="내용"
+            placeholder="이메일입력"
+            title="로그인정보"
+            check={false}
+            handleEdit={handleEdit}
+            error={error}
+            isSubmitted={isSubmitted}
+            defaultType={true}
+          />
+        }
+      />
     </Routes>
   );
 }

--- a/bookduck/src/components/common/TextField.jsx
+++ b/bookduck/src/components/common/TextField.jsx
@@ -1,19 +1,30 @@
 import { useState } from "react";
 //textfield의 type이 제목 field면 type=="제목", 내용 field면 type=="내용"
 //내용 type의 경우 title을 prop으로 입력 받음
-//수정 가능한 textfield의 경우 edit 값이 true, 이 경우 수정 관련 로직을 error, handleEdit로 넘겨줌
-
-const TextField = ({ type, title, edit, error, handleEdit }) => {
+//확인 가능한 textfield의 경우 edit 값이 true, 이 경우 확인 관련 로직을 error, handleEdit, isSubmitted로 넘겨줌
+//handleEdit에서 유효성 검사를 한 후 error값을 prop으로 넘겨줌
+//handleEdit 함수 수행 시에는 isSubmitted를 true값으로 바꿔 상태 업데이트 (default 상태와, 확인 후 error==true / false 상태를 구분하기 위함)
+//defaultType의 경우 에러메시지가 input 아래에 생기는 게 아니라 title 옆에 생김
+const TextField = ({
+  type,
+  title,
+  placeholder,
+  check = true,
+  error,
+  handleEdit,
+  isSubmitted,
+  defaultType,
+}) => {
   const [inputValue, setInputValue] = useState("");
   const handleValue = (e) => {
     setInputValue(e.target.value);
   };
   return (
     <>
-      {type == "내용" && (
+      {type === "내용" && (
         <div className="flex gap-[8px]">
           <div className="h-[16px] text-c1 text-gray-400">{title}</div>
-          {error && (
+          {defaultType && error && (
             <div className="text-c1 text-orange-600">필수입력란입니다!</div>
           )}
         </div>
@@ -22,22 +33,30 @@ const TextField = ({ type, title, edit, error, handleEdit }) => {
         <input
           value={inputValue}
           onChange={handleValue}
-          placeholder={type}
+          placeholder={placeholder}
           className={`w-[361px] h-[48px] px-[4px] py-[12px]  ${
-            error
+            !isSubmitted
+              ? "border-b-[1px] border-gray-200"
+              : error === true
               ? "border-b-[1px] border-orange-600"
-              : "border-b-[1px] border-gray-200"
+              : "border-b-[1px] border-blue"
           } text-b1 text-gray-800`}
         />
-        {!edit && (
+        {check && (
           <div
             onClick={handleEdit}
-            className="absolute top-[16px] right-[40px] text-c1 text-orange-400 cursor-pointer"
+            className="absolute top-[16px] right-[40px] text-b2 text-gray-600 cursor-pointer underline underline-offset-4"
           >
-            수정하기
+            확인
           </div>
         )}
       </div>
+      {/* 확인 버튼이 클릭된 경우에만 메시지 표시 */}
+      {!defaultType && isSubmitted && (
+        <div className={`text-c1 ${error ? "text-orange-600" : "text-blue"}`}>
+          {error ? "이미 사용 중인 이름입니다!" : "사용 가능한 이름입니다!"}
+        </div>
+      )}
     </>
   );
 };

--- a/bookduck/src/components/common/TextField.jsx
+++ b/bookduck/src/components/common/TextField.jsx
@@ -1,4 +1,44 @@
-const TextField = () => {
-  return;
+import { useState } from "react";
+//textfield의 type이 제목 field면 type=="제목", 내용 field면 type=="내용"
+//내용 type의 경우 title을 prop으로 입력 받음
+//수정 가능한 textfield의 경우 edit 값이 true, 이 경우 수정 관련 로직을 error, handleEdit로 넘겨줌
+
+const TextField = ({ type, title, edit, error, handleEdit }) => {
+  const [inputValue, setInputValue] = useState("");
+  const handleValue = (e) => {
+    setInputValue(e.target.value);
+  };
+  return (
+    <>
+      {type == "내용" && (
+        <div className="flex gap-[8px]">
+          <div className="h-[16px] text-c1 text-gray-400">{title}</div>
+          {error && (
+            <div className="text-c1 text-orange-600">필수입력란입니다!</div>
+          )}
+        </div>
+      )}
+      <div className="flex relative ">
+        <input
+          value={inputValue}
+          onChange={handleValue}
+          placeholder={type}
+          className={`w-[361px] h-[48px] pl-[4px] pr-[4px] pb-[12px] pt-[12px]  ${
+            error
+              ? "border-b-[1px] border-orange-600"
+              : "border-b-[1px] border-gray-200"
+          } text-b1 text-gray-800`}
+        />
+        {!edit && (
+          <div
+            onClick={handleEdit}
+            className="absolute top-[16px] right-[40px] text-c1 text-orange-400 cursor-pointer"
+          >
+            수정하기
+          </div>
+        )}
+      </div>
+    </>
+  );
 };
 export default TextField;

--- a/bookduck/src/components/common/TextField.jsx
+++ b/bookduck/src/components/common/TextField.jsx
@@ -23,7 +23,7 @@ const TextField = ({ type, title, edit, error, handleEdit }) => {
           value={inputValue}
           onChange={handleValue}
           placeholder={type}
-          className={`w-[361px] h-[48px] pl-[4px] pr-[4px] pb-[12px] pt-[12px]  ${
+          className={`w-[361px] h-[48px] px-[4px] py-[12px]  ${
             error
               ? "border-b-[1px] border-orange-600"
               : "border-b-[1px] border-gray-200"

--- a/bookduck/src/styles/reset.css
+++ b/bookduck/src/styles/reset.css
@@ -31,7 +31,6 @@ dfn,
 em,
 img,
 ins,
-input,
 kbd,
 q,
 s,
@@ -139,7 +138,6 @@ button {
   cursor: pointer;
 }
 input {
-  border: none;
   outline: none;
   appearance: none;
   border-radius: none;

--- a/bookduck/tailwind.config.js
+++ b/bookduck/tailwind.config.js
@@ -7,6 +7,7 @@ export default {
       colors: {
         white: "#FFF",
         black: "#000000",
+        blue: "#0066FF",
         orange: {
           300: "#FFBF68",
           400: "#FF9F1C",


### PR DESCRIPTION
# 구현 기능
  - TextField 컴포넌트 퍼블리싱
  - reset.css의 border:none 초기화 작업 제거

# 구현 상태 (선택)
![image](https://github.com/user-attachments/assets/e6cd67e4-54be-4042-9a3b-3f1bb755c67f)

![image](https://github.com/user-attachments/assets/9ec6cd27-edd5-4f63-9b59-9f4ffdc1c12d)

![image](https://github.com/user-attachments/assets/fff9e219-1b8f-4f40-b81e-2f1d22050f97)

# Resolve
  - 이슈 태그
  - #8 