### PR TITLE
Design/#7

### DIFF
--- a/bookduck/src/components/TabBarComponent.jsx
+++ b/bookduck/src/components/TabBarComponent.jsx
@@ -1,0 +1,51 @@
+/* eslint-disable react/prop-types */
+/*사용예시
+<TabBar
+    tabs={["전체보기", "발췌", "감상평"]}
+    activeTab={tab}
+    onTabClick={setTab}
+    size="big"
+/>
+*/
+const TabBarComponent = ({
+  tabs,
+  activeTab,
+  onTabClick,
+  size = "big",
+  ...props
+}) => {
+  const isBig = size === "big";
+
+  return (
+    <div
+      className={`flex items-center w-full h-[40px] px-[16px] border-b-[1px] border-gray-200 ${
+        isBig ? "justify-around" : "space-x-[32px]"
+      }`}
+      {...props}
+    >
+      {tabs.map((tab, index) => (
+        <div
+          key={index}
+          onClick={() => onTabClick(tab)}
+          className={`${
+            isBig ? "flex-1" : ""
+          } text-center cursor-pointer relative`}
+        >
+          <div className={activeTab === tab ? "text-black" : "text-gray-500"}>
+            {tab}
+          </div>
+
+          {activeTab === tab && (
+            <div
+              className={`absolute bottom-[-12px] left-0 right-0 h-[2px] bg-black ${
+                isBig ? "w-[64px] justify-self-center" : ""
+              }`}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TabBarComponent;


### PR DESCRIPTION
# 구현 기능
  - 클릭하면 밑줄이 옮겨지는 TabBar입니다.  size가 디자인에 따라 big, small로 나뉘는데 big은 flex-1로 전체 공간을 나눠 쓰게, small은 gap을 두어 왼쪽에 정렬되어 있게 하였습니다.

# 구현 상태
 
<img width="436" alt="스크린샷 2024-10-11 오후 4 26 53" src="https://github.com/user-attachments/assets/9545d60c-3bf9-4cc1-bbcf-53ab3393cdee">
<img width="426" alt="스크린샷 2024-10-11 오후 4 23 49" src="https://github.com/user-attachments/assets/f8722126-47e7-457f-ac42-ec14f0038ef3">


# Resolve
  - 이슈 태그(ex: #7)
